### PR TITLE
Change key to string to allow "320w" etc in generated srcset

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ gulp.task('views', function() {
 You put html in:
 ``` html
 
-	<img clas="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" />
+	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" />
 ```
 
 And get html out:
 ``` html
 
-	<img data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
+	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
 ```
 
 ## Options (Optional)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And get html out:
 
 	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
 ```
-placeholder
+Responsive Images with breakpoints
 
 ``` js
 var gulp = require('gulp');
@@ -63,6 +63,17 @@ gulp.task('views', function() {
     .pipe(gulp.dest('./build'));
 
 });
+```
+You put html in:
+``` html
+
+	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" />
+```
+
+And get html out:
+``` html
+
+	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example-320x.jpg 320w, images/default/example-640x.jpg 640w, images/default/example-960x.jpg 960w" />
 ```
 
 ## Options (Optional)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gulp-lazysizes-srcset
+# gulp-lazysizes-data-srcset
 
 ## Install
 
-`npm install gulp-lazysizes-srcset`
+`npm install gulp-lazysizes-data-srcset`
 
 ## Usage
 
@@ -18,7 +18,7 @@ Responsive Images For Retina
 
 ``` js
 var gulp = require('gulp');
-var lazyScr = require('gulp-lazysizes-srcset');
+var lazyScr = require('gulp-lazysizes-data-srcset');
 
 gulp.task('views', function() {
 
@@ -49,7 +49,7 @@ Responsive Images with breakpoints
 
 ``` js
 var gulp = require('gulp');
-var lazyScr = require('gulp-lazysizes-srcset');
+var lazyScr = require('gulp-lazysizes-data-srcset');
 
 gulp.task('views', function() {
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gulp.task('views', function() {
     decodeEntities: false,
 	data_src: 'data-src',
 	data_srcset: 'data-srcset',
-	suffix: {1: '@1x', 2: '@2x', 3: '@3x', 4: ''}
+	suffix: {'1x': '@1x', '2x': '@2x', '3x': '@3x', '4x': ''}
 	}))
     .pipe(gulp.dest('./build'));
 
@@ -37,13 +37,13 @@ gulp.task('views', function() {
 You put html in:
 ``` html
 
-	<img src="images/default/example.jpg" data-sizes="auto" alt="example image" />
+	<img clas="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" />
 ```
 
 And get html out:
 ``` html
 
-	<img src="images/default/example.jpg" data-sizes="auto" alt="example image" srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
+	<img data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
 ```
 
 ## Options (Optional)
@@ -51,6 +51,6 @@ And get html out:
 ### options.suffix
 Type: ```Object```
 
-Default: ```{1: '@1x', 2: '@2x', 3: '@3x'}```
+Default: ```{'1x': '@1x', '2x': '@2x', '3x': '@3x'}```
 
 The suffix will insert to image's path, the key is resolution, and value is suffix.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ gulp.task('views', function() {
     decodeEntities: false,
 	data_src: 'data-src',
 	data_srcset: 'data-srcset',
-	suffix: {'1x': '@1x', '2x': '@2x', '3x': '@3x', '4x': ''}
+	suffix: {'1x': '@1x', '2x': '@2x', '3x': '@3x'}
 	}))
     .pipe(gulp.dest('./build'));
 
 });
 ```
-
 
 You put html in:
 ``` html
@@ -44,6 +43,25 @@ And get html out:
 ``` html
 
 	<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
+```
+placeholder
+
+``` js
+var gulp = require('gulp');
+var lazyScr = require('gulp-lazysizes-srcset');
+
+gulp.task('views', function() {
+
+  return gulp.src('./src/*.html')
+    .pipe(lazyScr({
+    decodeEntities: false,
+	data_src: 'data-src',
+	data_srcset: 'data-srcset',
+	suffix: {'320w': '-320x', '640w': '-640x', '960w': '-960x'}
+	}))
+    .pipe(gulp.dest('./build'));
+
+});
 ```
 
 ## Options (Optional)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 img[data-sizes]{width:100%;}
 </style>
 ```
+Responsive Images For Retina
 
 ``` js
 var gulp = require('gulp');

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ var reImageSrc = /^((?:(?:http|https):\/\/)?(?:.+))(\.(?:gif|png|jpg|jpeg|webp|s
 
 var defaultOptions = {
 	decodeEntities: false,
-	data_src: 'src',
-	data_srcset: 'srcset',
-	suffix: {1: '@1x', 2: '@2x', 3: '@3x'}
+	data_src: 'data-src',
+	data_srcset: 'data-srcset',
+	suffix: {'1x': '@1x', '2x': '@2x', '3x': '@3x'}
 }
 
 var lazyScr = function(options){
@@ -33,25 +33,25 @@ var lazyScr = function(options){
 		var $ = cheerio.load( content, options );
 
 		var imgList = $('img[data-sizes]');
-		
+
 		imgList.each(function(item){
 			var _this = $(this);
 			var _src = _this.attr(options.data_src);
 			var tmpSrc = [];
-			
+
 			var match = _src.match(reImageSrc);
-			
+
 			// not a valid src attribute
 			if (match === null){
 				return true;
 			}
 
 			for( var key in options.suffix ){
-				tmpSrc.push( match[1] + options.suffix[key] + match[2] +' '+ key + 'x' );
+				tmpSrc.push( match[1] + options.suffix[key] + match[2] +' '+ key );
 			}
-			
+
 			_this.attr(options.data_srcset, tmpSrc.join(', '));
-		
+
 		});
 		// console.log($.html());
 


### PR DESCRIPTION
If index.js file is modified as below:

```
for( var key in options.suffix ){
	tmpSrc.push( match[1] + options.suffix[key] + match[2] +' '+ key );
}
```

and defaultOptions changed to

```
var defaultOptions = {
	decodeEntities: false,
	data_src: 'data-src',
	data_srcset: 'data-srcset',
	suffix: {'1x': '@1x', '2x': '@2x', '3x': '@3x'}
}
```
or
```
var defaultOptions = {
	decodeEntities: false,
	data_src: 'data-src',
	data_srcset: 'data-srcset',
	suffix: {'320w': '-320x', '640w': '-640x', '960w': '-960x'}
}
```
And get html out
```
<img class="lazyload"  data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example@1x.jpg 1x, images/default/example@2x.jpg 2x, images/default/example@3x.jpg 3x" />
```
or
```
<img class="lazyload" data-src="images/default/example.jpg" data-sizes="auto" alt="example image" data-srcset="images/default/example-320x.jpg 320w, images/default/example-640x.jpg 640w, images/default/example-960x.jpg 960w" />
```